### PR TITLE
feat(): add svg icon and indention to collapse menu

### DIFF
--- a/src/img/collapse-menu.svg
+++ b/src/img/collapse-menu.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/src/js/directives/mdCollapseMenuItem.js
+++ b/src/js/directives/mdCollapseMenuItem.js
@@ -18,7 +18,7 @@ function MdCollapseMenuItem($compile, $timeout) {
     var $ul = angular.element(element[0].querySelectorAll('ul'));
 
     // Compile our placeholder into the current scope.
-    var collapsePlaceholder = angular.element('<md-menu-item ng-label="{{ ngLabel }}"></md-menu-item>');
+    var collapsePlaceholder = angular.element('<md-menu-item type="icon" ng-label="{{ ngLabel }}"></md-menu-item>');
     collapsePlaceholder = $compile(collapsePlaceholder)(scope);
 
     // Append our actual placeholder before the <ul>

--- a/src/js/directives/mdMenuItem.js
+++ b/src/js/directives/mdMenuItem.js
@@ -3,7 +3,12 @@ angular.module('wgHilfe')
     return {
       restrict: 'AE',
       replace: false,
-      template: '<md-button ng-href="{{ ngHref }}">{{ ngLabel }}</md-button>',
+      template: function(elem, attr) {
+        return attr.type == 'icon' ?
+          '<md-button layout-row ng-href="{{ ngHref }}">{{ ngLabel }}<span flex></span>' +
+          '<span class="md-toggle-icon"><md-icon md-svg-src="img/collapse-menu.svg"></md-icon>' +
+          '</span></md-button>' : '<md-button ng-href="{{ ngHref }}">{{ ngLabel }}</md-button>';
+      },
       scope: {
         ngHref: "@",
         ngLabel: "@"

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -32,7 +32,6 @@ a {
   color: grey;
 }
 
-
 md-sidenav {
 
   .brand {
@@ -56,11 +55,17 @@ md-menu-item {
 md-collapse-menu-item {
 
   ul {
+
+    .md-button {
+      padding: 0 16px 0 32px;
+      text-overflow: hidden;
+      word-break: keep-all;
+    }
+
     position: relative;
     overflow: hidden;
     transition: height 0.6s cubic-bezier(0.35, 0, 0.25, 1);
     max-width: 100%;
-
     margin: 0;
     padding: 0;
     list-style: none;
@@ -87,5 +92,4 @@ div[marked] {
     background-color: #f7f7f7;
     border-radius: 3px;
   }
-
 }


### PR DESCRIPTION
add svg icon and indention to collapse menu for responsive use:
![https://gyazo.com/ccf8e43caf09d70b73687e79091ca5f8](https://i.gyazo.com/ccf8e43caf09d70b73687e79091ca5f8.png)
