### PR TITLE
fix(app.scss): word wrapping

### DIFF
--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -78,7 +78,7 @@ md-collapse-menu-item {
 
 div[marked] {
   overflow: hidden;
-  word-break: break-all;
+  word-break: normal;
 
   img {
     max-width: 100%;


### PR DESCRIPTION
Prevents the words in the tutorials to be wrapped

Reference 84